### PR TITLE
Add assertion in Deadline.java

### DIFF
--- a/src/main/java/gibson/task/Deadline.java
+++ b/src/main/java/gibson/task/Deadline.java
@@ -26,6 +26,7 @@ public class Deadline extends Task {
         if (date.isBlank()) {
             throw new IllegalArgumentException("Time of deadline cannot be empty.");
         } else {
+            assert FORMATS.length > 0 : "No DateTime format provided.";
             for (int i = 0; i < FORMATS.length; i++) {
                 try {
                     this.date = LocalDateTime.parse(date, DateTimeFormatter.ofPattern(FORMATS[i]));


### PR DESCRIPTION
Construction of Deadline object will not work if FORMATS array is
empty.

Adding an assertion ensures developers have at least 1 element in
the FORMATS array if they were to change it.